### PR TITLE
Add Heroku start and postbuild scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview --port $PORT --host 0.0.0.0",
+    "heroku-postbuild": "npm run build"
   },
   "dependencies": {
     "react": "^19.1.1",


### PR DESCRIPTION
## Summary
- serve built app via `npm start` using Heroku's provided port and 0.0.0.0 host
- ensure Heroku deployment builds assets with `heroku-postbuild`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689971b67698832f993c702b55551152